### PR TITLE
Add `noindex` and `nofollow` tags to prevent crawlers from indexing the WIP site

### DIFF
--- a/en/theme/material/base.html
+++ b/en/theme/material/base.html
@@ -8,6 +8,7 @@
     {% block site_meta %}
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width,initial-scale=1">
+      <meta name="robots" content="noindex, nofollow">
       {% if page.meta and page.meta.description %}
         <meta name="description" content="{{ page.meta.description }}">
       {% elif config.site_description %}


### PR DESCRIPTION
## Purpose

This PR is to add `noindex` and `nofollow` tags to prevent search engine crawlers from indexing the documentation site.

**Reference:** 

- https://squidfunk.github.io/mkdocs-material/reference/?h=robots#on-all-pages
- https://developers.google.com/search/docs/crawling-indexing/block-indexing