### PR TITLE
Remove bold font-weight from links in content, navigation, and tabs

### DIFF
--- a/en/docs/assets/css/blue-palette-alt1.css
+++ b/en/docs/assets/css/blue-palette-alt1.css
@@ -81,7 +81,6 @@
 }
 .md-content a {
     color: var(--md-typeset-a-color);
-    font-weight: bold;
 }
 
 .md-content a:hover {
@@ -94,7 +93,6 @@
 
 .md-nav__link--active {
     color: var(--md-nav-link-color);
-    font-weight: bold;
 }
 
 .md-tabs__link:hover {
@@ -103,5 +101,4 @@
 
 .md-tabs__link--active {
     color: var(--md-nav-link-color);
-    font-weight: bold;
 }


### PR DESCRIPTION
Updates the styling for links within the main content, navigation menus, and tab components by removing the bold font-weight. This change reduces visual clutter and ensures a more consistent text hierarchy across the documentation pages.

## Purpose
> Reduces visual clutter and ensures a more consistent text hierarchy across the documentation pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual styling for links and active navigation states by removing bold emphasis, creating a lighter and more consistent appearance throughout the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->