### PR TITLE
Add Usecases to Home page

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -43,7 +43,7 @@
             {"name": "AI Agents and other Gen AI Integrations", "url": "integration-guides/ai/agents"},
             {"name": "Integration as API", "url": "integration-guides/integration-as-api/service-orchestration/"},
             {"name": "File Integration", "url": "integration-guides/file-integration/file-integration-with-directory-service/"},
-            {"name": "Use cases", "url": "integration-guides/usecases/datamapper/overview/"}
+            {"name": "Use Cases", "url": "integration-guides/usecases/datamapper/overview/"}
         ]
     },
     {


### PR DESCRIPTION
Add "Use Cases" link to the integration guides section in home page

<img width="2478" height="1251" alt="image" src="https://github.com/user-attachments/assets/30c4b773-efee-490a-bb9f-aa5ca15131e8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new "Use Cases" integration guide link to the Integration Guides section.

* **Bug Fixes**
  * Fixed JSON syntax in the integration guides links configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->