### PR TITLE
Remove redundant lines and improve clarity in the CSV to XML transformation guide

### DIFF
--- a/en/docs/integration-guides/usecases/datamapper/overview.md
+++ b/en/docs/integration-guides/usecases/datamapper/overview.md
@@ -3,8 +3,6 @@
 The Data Mapper in WSO2 Integrator: BI enables you to visually transform data between formats, such as JSON, XML, and CSV, using an intuitive, low-code interface.  
 This section provides a collection of end-to-end transformation examples that demonstrate practical, real-world integrations across various formats.
 
----
-
 ## What you’ll learn
 
 Each use case in this section helps you understand how to:
@@ -13,8 +11,6 @@ Each use case in this section helps you understand how to:
 - Use inline or reusable Data Mappers.
 - Apply mappings, aggregations, and expressions to manipulate data visually.
 - Integrate transformations into automation or other integration flows.
-
----
 
 ## Available use cases
 
@@ -25,8 +21,6 @@ Each use case in this section helps you understand how to:
 | *Coming soon:* XML to JSON                                                              | Illustrates how to map XML elements into a simplified JSON representation. |
 | *Coming soon:* CSV to JSON                                                              | Walks through mapping tabular data from a CSV file into structured JSON objects. |
 
----
-
 ## When to use data mapper
 
 Use the Data Mapper when you need to:
@@ -36,12 +30,8 @@ Use the Data Mapper when you need to:
 - Create API payload transformations between client-facing and backend schemas.
 - Minimize manual code and maintain readable, visual mappings.
 
----
-
 ## Related topics
 
 - [Data Mapping Quick Start](../../../developer-guides/data-mapping.md)
 - [Design the Integrations](../../../developer-guides/design-the-integrations.md)
 - [Create a Project](../../../developer-guides/create-a-project.md)
-
----

--- a/en/docs/integration-guides/usecases/datamapper/read-csv-file-and-transform-to-xml-file.md
+++ b/en/docs/integration-guides/usecases/datamapper/read-csv-file-and-transform-to-xml-file.md
@@ -86,8 +86,6 @@ WSO2 Integrator: BI extension provides a low-code graphical environment to visua
 
  <a href="{{base_path}}/assets/integration-guides/usecases/datamapping/csv-to-xml-simple-mapping/img/csv_to_xml1.gif"><img src="{{base_path}}/assets/integration-guides/usecases/datamapping/csv-to-xml-simple-mapping/img/csv_to_xml1.gif" alt="Create Integration" width="70%"></a>
 
----
-
 ## Step 2: Add configurable variables
 
 In this step, you will define the input and output file paths as configurable variables.  
@@ -120,7 +118,6 @@ These parameters make your integration portable and environment-agnostic — you
 
 <a href="{{base_path}}/assets/integration-guides/usecases/datamapping/csv-to-xml-simple-mapping/img/csv_to_xml2.gif"><img src="{{base_path}}/assets/integration-guides/usecases/datamapping/csv-to-xml-simple-mapping/img/csv_to_xml2.gif" alt="Add configurable file paths" width="70%"></a>
 
----
 ## Step 3: Create a structure to represent each csv row
 
 In this step, you’ll define a structure (called a *Type* in Ballerina) that describes what one row in your CSV file looks like.  
@@ -148,7 +145,6 @@ Instead of dealing with raw text lines, it can now work with meaningful fields l
 
 <a href="{{base_path}}/assets/integration-guides/usecases/datamapping/csv-to-xml-simple-mapping/img/csv_to_xml3.gif"><img src="{{base_path}}/assets/integration-guides/usecases/datamapping/csv-to-xml-simple-mapping/img/csv_to_xml3.gif" alt="Create a type to represent CSV structure" width="70%"></a>
 
----
 ## Step 4: Generate xml types from a sample payload
 
 In this step, you’ll create the XML output structure automatically by pasting a sample XML.  
@@ -206,7 +202,6 @@ This type will act as the target structure in the Data Mapper, allowing each `CS
 
 <a href="{{base_path}}/assets/integration-guides/usecases/datamapping/csv-to-xml-simple-mapping/img/csv_to_xml4.gif"><img src="{{base_path}}/assets/integration-guides/usecases/datamapping/csv-to-xml-simple-mapping/img/csv_to_xml4.gif" alt="Create a type to represent XML structure" width="70%"></a>
 
----
 ## Step 5: Create an automation and set up CSV reading
 
 In this step, you’ll create an **Automation** entry point in WSO2 Integrator: BI and configure it to read a CSV file from the path defined in your configurable variable (`inputCSV`).  
@@ -584,4 +579,3 @@ Run the integration. On success, the XML produced from `xmlRecord` will be writt
 
 ???+ tip "Note"
     Now you have successfully converted a CSV file to a XML file.
----


### PR DESCRIPTION
## Purpose
The documentation currently contains inconsistent usage of horizontal rules (`---`) between headers. 

## Goals
* Improve visual consistency across the `bi-docs` repository.

## Approach
* Identified and removed the horizontal rule (`---`) syntax located between headers in `.md` files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added learning objectives for Data Mapper functionality, including Type Editor usage and integration patterns
* Introduced new use case guide: "Read CSV File and Transform to XML File" with detailed step-by-step instructions
* Added helpful tip confirming successful CSV-to-XML conversion
* Enhanced documentation formatting and clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->