### PR TITLE
Fix documentation build failure due to missing setuptools dependency

### DIFF
--- a/en/requirements.txt
+++ b/en/requirements.txt
@@ -1,3 +1,4 @@
+setuptools==68.0.0
 mkdocs==1.4.2
 Pygments==2.14.0
 mkdocs-material==9.1.2


### PR DESCRIPTION
## Purpose
> Fix the build failing in the deployment

### Root Cause
Python 3.12+ no longer includes `setuptools` by default. The `markdown` package depends on `pkg_resources` (from setuptools), causing the build to fail.

### Solution
Added `setuptools==68.0.0` to `en/requirements.txt` to ensure the dependency is available in all environments.

### Testing
✅ Verified locally with `mkdocs build` - build completes successfully  
✅ All dependencies install correctly

### Changes
- Added `setuptools==68.0.0` to `en/requirements.txt`

---

This fix ensures the documentation builds successfully in CI/CD pipelines running Python 3.12+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->