### PR TITLE
Adjust heading levels in guides for improved structure.

### DIFF
--- a/en/docs/get-started/develop-ai-agent.md
+++ b/en/docs/get-started/develop-ai-agent.md
@@ -15,7 +15,7 @@ Before you begin, make sure you have the following:
     1. Sign up at [OpenAI](https://platform.openai.com/signup/).
     2. Get an API key from the [API section](https://platform.openai.com/docs/api-reference/authentication).
 
-### Step 1: Create a new integration project
+## Step 1: Create a new integration project
 
 1. Click on the **BI** icon in the sidebar.
 2. Click on the **Create New Integration** button.
@@ -25,7 +25,7 @@ Before you begin, make sure you have the following:
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/agents/introduction-to-inline-agents/inline-agent-create-a-new-integration-project.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/agents/introduction-to-inline-agents/inline-agent-create-a-new-integration-project.gif" alt="Create a new integration project" width="70%"></a>
 
-### Step 2: Create a GraphQL service
+## Step 2: Create a GraphQL service
 
 1. Click the **+** button on the WSO2 Integrator: BI side panel or navigate back to the design screen and click on **Add Artifact**.
 2. Select **GraphQL Service** under the **Integration as API** artifacts.
@@ -33,7 +33,7 @@ Before you begin, make sure you have the following:
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/agents/introduction-to-inline-agents/inline-agent-create-a-graphql-service.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/agents/introduction-to-inline-agents/inline-agent-create-a-graphql-service.gif" alt="Create a GraphQL service" width="70%"></a>
 
-### Step 3: Create a GraphQL resolver
+## Step 3: Create a GraphQL resolver
 
 1. Click the **+ Create Operations** button in the GraphQL design view.
 2. In the side panel, click the **+** button in the **Mutation** section to add a mutation operation.
@@ -46,7 +46,7 @@ Before you begin, make sure you have the following:
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/agents/introduction-to-inline-agents/inline-agent-create-a-graphql-resolver.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/agents/introduction-to-inline-agents/inline-agent-create-a-graphql-resolver.gif" alt="Create a GraphQL resolver" width="70%"></a>
 
-### Step 4: Implement the resolving logic with an inline agent
+## Step 4: Implement the resolving logic with an inline agent
 
 1. Click the created `task` operation in the side panel to navigate to the resolver editor view.
 2. Click the **+** button in the flow to open the side panel.
@@ -66,7 +66,7 @@ At this point, we've created a GraphQL resolver that takes a user-provided `quer
 !!! note
     You must implement a query operation to have a valid GraphQL service. Similar to creating the `task` operation in Step 3, add an operation named `greet` by pressing the **+** button in the **Query** section, without any input parameters. For the implementation, you can simply return a string literal saying `"welcome"`.
 
-### Step 5: Run the integration and query the agent
+## Step 5: Run the integration and query the agent
 
 1. Click on the **Run** button in the top-right corner to run the integration.
 2. Query the agent by sending the mutation request below.

--- a/en/docs/integration-guides/ai/direct-llm-call/direct-llm-invocation-with-ballerina-model-providers.md
+++ b/en/docs/integration-guides/ai/direct-llm-call/direct-llm-invocation-with-ballerina-model-providers.md
@@ -5,11 +5,7 @@ With Ballerina, you can send a prompt along with a type descriptor, instructing 
 
 In this tutorial, you’ll leverage this capability to analyze blog content—prompting the LLM to return a structured review, including a suggested category and a rating, using the default WSO2 model provider.
 
-## Implementation
-
-Follow the steps below to implement the integration.
-
-### Step 1: Create a new integration project
+## Step 1: Create a new integration project
 
 1. Click on the WSO2 Integrator: BI icon on the sidebar.
 2. Click on the **`Create New Integration`** button.
@@ -17,7 +13,7 @@ Follow the steps below to implement the integration.
 4. Click the **`Select Path`** button to set the Integration Path.
 5. Click on the **`Create New Integration`** button to create the integration project.
 
-### Step 2: Define types
+## Step 2: Define types
 
 1. Click on the **`Add Artifacts`** button and select **`Type`** in the **`Other Artifacts`** section.
 2. Click on **`+ Add Type`** to add a new type.
@@ -45,7 +41,7 @@ Follow the steps below to implement the integration.
     <a href="{{base_path}}/assets/img/learn/references/direct-llm-call/types_direct_llm_call.png"><img src="{{base_path}}/assets/img/learn/references/direct-llm-call/types_direct_llm_call.png" alt="Define types" width="70%"></a>
 
 
-### Step 3: Create an HTTP service
+## Step 3: Create an HTTP service
 1. In the design view, click the **`Add Artifact`** button.
 2. Select **`HTTP Service`** under the **`Integration as API`** category.
 3. Select the **`Design from Scratch`** option as the **`Service Contract`** and use `/blogs` as the **`Service base path`**.
@@ -61,7 +57,7 @@ Follow the steps below to implement the integration.
 
     <a href="{{base_path}}/assets/img/learn/references/direct-llm-call/update_resource_direct_llm_call_docs.gif"><img src="{{base_path}}/assets/img/learn/references/direct-llm-call/update_resource_direct_llm_call_docs.gif" alt="Create HTTP service" width="70%"></a>
 
-### Step 4: Implement the resource logic
+## Step 4: Implement the resource logic
 1. Once redirected to the `review` resource implementation designer view, follow these steps to implement the logic:
 2. Hover over the arrow after the Start node and click the ➕ button to add a new action to the resource.
 3. Select **`Model Provider`** from the node panel.
@@ -100,14 +96,14 @@ Follow the steps below to implement the integration.
 
     <a href="{{base_path}}/assets/img/learn/references/direct-llm-call/return_node_direct_llm_call_docs.gif"><img src="{{base_path}}/assets/img/learn/references/direct-llm-call/return_node_direct_llm_call_docs.gif" alt="Add Return" width="70%"></a>
 
-### Step 5: Configure default WSO2 model provider
+## Step 5: Configure default WSO2 model provider
 
 1. Ballerina supports direct calls to Large Language Models (LLMs) with various providers, such as OpenAI, Azure OpenAI, and Anthropic. This demonstration focuses on using the Default Model Provider (WSO2). To begin, you need to configure its settings:
     - Press `Ctrl/Cmd + Shift + P` to open the VS Code command palette.
     - Run the command: `Ballerina: Configure default WSO2 model provider`.
    This will automatically generate the required configuration entries.
 
-### Step 6: Run the integration
+## Step 6: Run the integration
 
 !!! warning "Response May Vary"
     Since this integration involves an LLM (Large Language Model) call, the response values may not always be identical across different executions.

--- a/en/docs/integration-guides/ai/mcp-service/mcp-service.md
+++ b/en/docs/integration-guides/ai/mcp-service/mcp-service.md
@@ -14,7 +14,7 @@ Before you begin, ensure you have WSO2 Integrator: BI installed and configured i
 !!! note "What is an MCP Service?"
     An MCP service acts as a bridge between AI assistants and external systems. It exposes a set of tools—functions that AI assistants can call to perform specific tasks like fetching data, executing operations, or interacting with APIs. The AI assistant discovers available tools through the MCP protocol and invokes them as needed during conversations.
 
-### Step 1: Create a new integration project
+## Step 1: Create a new integration project
 
 1. Click on the **BI** icon in the sidebar.
 2. Click on the **Create New Integration** button.
@@ -24,7 +24,7 @@ Before you begin, ensure you have WSO2 Integrator: BI installed and configured i
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/mcp/mcp-service/create-a-new-integration-project.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/mcp/mcp-service/create-a-new-integration-project.gif" alt="Create a new integration project" width="70%"></a>
 
-### Step 2: Create an MCP service
+## Step 2: Create an MCP service
 
 In WSO2 Integrator: BI, an MCP service is an artifact that exposes tools following the Model Context Protocol standard. AI assistants can connect to this service to discover and invoke the tools you define.
 
@@ -36,7 +36,7 @@ In WSO2 Integrator: BI, an MCP service is an artifact that exposes tools followi
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/mcp/mcp-service/create-an-mcp-service.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/mcp/mcp-service/create-an-mcp-service.gif" alt="Create an MCP service" width="70%"></a>
 
-### Step 3: Define tools for the MCP service
+## Step 3: Define tools for the MCP service
 
 Tools are the core building blocks of an MCP service. Each tool represents a specific capability that AI assistants can invoke.
 
@@ -56,7 +56,7 @@ Tools are the core building blocks of an MCP service. Each tool represents a spe
 !!! note
     Tool descriptions are important—they help AI assistants understand when and how to use each tool. Write clear, concise descriptions that explain what the tool does and what input it expects.
 
-### Step 4: Implement tool logic
+## Step 4: Implement tool logic
 
 Now you'll implement the logic that executes when the tool is invoked. For this example, we'll use conditional logic to simulate weather data retrieval.
 
@@ -83,7 +83,7 @@ Now you'll implement the logic that executes when the tool is invoked. For this 
 !!! note
     This example uses simple conditional logic for demonstration purposes. In a real-world scenario, you would integrate with actual weather APIs using [HTTP connectors]({{base_path}}/developer-guides/protocols-and-connectors/overview-of-connectors/) or other data sources available in WSO2 Integrator: BI.
 
-### Step 5: Add more tools (optional)
+## Step 5: Add more tools (optional)
 
 You can extend your MCP service with additional tools to provide more capabilities.
 
@@ -92,7 +92,7 @@ You can extend your MCP service with additional tools to provide more capabiliti
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/mcp/mcp-service/add-more-tools.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/mcp/mcp-service/add-more-tools.gif" alt="Add more tools" width="70%"></a>
 
-### Step 6: Test the MCP service
+## Step 6: Test the MCP service
 
 Once you have defined and implemented your tools, you can test the MCP service to ensure it works correctly.
 

--- a/en/docs/integration-guides/ai/natural-functions/natural-functions.md
+++ b/en/docs/integration-guides/ai/natural-functions/natural-functions.md
@@ -7,17 +7,14 @@ The tutorial uses a natural function to analyze blog content to suggest a suitab
     To learn more about natural programming and natural functions, see [Natural Language is Code: A hybrid approach with Natural Programming](https://blog.ballerina.io/posts/2025-04-26-introducing-natural-programming/).
 
 
-## Implementation
-Follow the steps below to implement the integration.
-
-### Step 1: Create a new integration project
+## Step 1: Create a new integration project
 1. Click on the **BI** icon on the sidebar.
 2. Click on the **`Create New Integration`** button.
 3. Enter `BlogReviewer` as the project name.
 4. Select Project Directory and click on the **`Select Location`** button.
 5. Click on the **`Create New Integration`** button to create the integration project.
 
-### Step 2: Define Types
+## Step 2: Define Types
 1. Click on the **`Add Artifacts`** button and select **`Type`** in the **`Other Artifacts`** section.
 2. Click on **`+ Add Type`** to add a new type and switch to the **`Import`** section. 
 3. Enter `Blog` as the **`Name`**, paste the following JSON payload, and then click the **`Import`** button.
@@ -43,7 +40,7 @@ Follow the steps below to implement the integration.
     <a href="{{base_path}}/assets/img/integration-guides/ai/natural-functions/types.png"><img src="{{base_path}}/assets/img/integration-guides/ai/natural-functions/types.png" alt="Types" width="70%"></a>
 
 
-### Step 3: Add a Natural Function
+## Step 3: Add a Natural Function
 1. Click on the **`Add Artifact`** button and select **`Natural Function`** under the **`Other Artifacts`** category.
 2. Use `reviewBlog` as the name of the function. Then click the **`Add Parameter`** button to add a parameter of type `Blog` named `blog`. Use `Review` as the return type and convert it to nilable type using type operators. Then click on the **`Create`** button.
 
@@ -76,7 +73,7 @@ Follow the steps below to implement the integration.
     <a href="{{base_path}}/assets/img/integration-guides/ai/natural-functions/natural-function-view.png"><img src="{{base_path}}/assets/img/integration-guides/ai/natural-functions/natural-function-view.png" alt="natural function view" width="70%"></a>
 
 
-### Step 4: Create an HTTP service
+## Step 4: Create an HTTP service
 1. In the design view, click on the **`Add Artifact`** button.
 2. Select **`HTTP Service`** under the **`Integration as API`** category.
 3. Select the **`Create and use the default HTTP listener (port: 9090)`** option from the **`Listeners`** dropdown.
@@ -95,7 +92,7 @@ Follow the steps below to implement the integration.
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/natural-functions/update-resource.png"><img src="{{base_path}}/assets/img/integration-guides/ai/natural-functions/update-resource.png" alt="Resource" width="70%"></a>
 
-### Step 5: Implement the resource logic
+## Step 5: Implement the resource logic
 1. Click on the `review` resource to navigate to the resource implementation designer view.
 2. Hover over the arrow after start and click the ➕ button to add a new action to the resource.
 3. Select **`Call Natural Function`** from the node panel.
@@ -111,13 +108,13 @@ Follow the steps below to implement the integration.
 
 8. The resource implementation is now complete. The function `reviewBlog` is called with the `blog` content as input, and the `review` is returned as the response.
 
-### Step 6: Configure model for natural function
+## Step 6: Configure model for natural function
 1. Press `Ctrl + Shift + P` on Windows and Linux, or `Shift + ⌘ + P` on a Mac, and type `>Ballerina: Configure default model for natural functions (Experimental)` to configure the default model for natural functions. 
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/natural-functions/configure-model.png"><img src="{{base_path}}/assets/img/integration-guides/ai/natural-functions/configure-model.png" alt="Configure Model" width="70%"></a>
 
 
-### Step 7: Run the integration
+## Step 7: Run the integration
 
 !!! warning "Response May Vary"
     Since this integration involves an LLM (Large Language Model) call, the response values may not always be identical across different executions.

--- a/en/docs/integration-guides/ai/rag/rag-ingestion.md
+++ b/en/docs/integration-guides/ai/rag/rag-ingestion.md
@@ -16,7 +16,7 @@ To get started, you need a knowledge file (in Markdown format) that you want to 
 !!! note "What is an In-Memory Vector Store?"
     An in-memory vector store holds your data (the chunked and embedded text) directly in your computer's active memory (RAM). This makes it very fast and easy to set up, as it requires no external databases or services. However, this data is temporary—it will be completely erased when you stop the integration or close the project. 
 
-### Step 1: Create a new integration project
+## Step 1: Create a new integration project
 
 1. Click on the **BI** icon in the sidebar.
 2. Click on the **Create New Integration** button.
@@ -26,7 +26,7 @@ To get started, you need a knowledge file (in Markdown format) that you want to 
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/rag/rag-ingestion/create-a-new-integration-project.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/rag/rag-ingestion/create-a-new-integration-project.gif" alt="Create a new integration project" width="70%"></a>
 
-### Step 2: Create an automation
+## Step 2: Create an automation
 
 In WSO2 Integrator: BI, an [automation]({{base_path}}/developer-guides/wso2-integrator-bi-artifacts/#automation) is a flow that runs automatically when the integration starts. We will use this to ensure our data is loaded and ingested into the knowledge base as soon as the application is running, making it ready for the query service.
 
@@ -36,7 +36,7 @@ In WSO2 Integrator: BI, an [automation]({{base_path}}/developer-guides/wso2-inte
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/rag/rag-ingestion/create-an-automation.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/rag/rag-ingestion/create-an-automation.gif" alt="Create an automation" width="70%"></a>
 
-### Step 3: Create a text data loader
+## Step 3: Create a text data loader
 
 1. Hover over the flow line and click the **+** icon to open the side panel.
 2. Click on **Data Loader** from the **AI** section.
@@ -48,7 +48,7 @@ In WSO2 Integrator: BI, an [automation]({{base_path}}/developer-guides/wso2-inte
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/rag/rag-ingestion/create-a-data-loader.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/rag/rag-ingestion/create-a-data-loader.gif" alt="Create a data loader" width="70%"></a>
 
-### Step 4: Load data using the data loader
+## Step 4: Load data using the data loader
 
 1. In the **Data Loaders** section, click on `loader`.
 2. Click on **load** to open the configuration panel.
@@ -62,7 +62,7 @@ This step wraps the file content into a `ai:Document` record, preparing it for c
 !!! note
     In WSO2 Integrator: BI, an `ai:Document` is a generic container that wraps the content of any data source—such as a file, webpage, or database entry. It not only holds the main content but can also include additional metadata, which becomes useful during retrieval operations in RAG workflows. In this tutorial, no metadata is used.
 
-### Step 5: Create a vector knowledge base
+## Step 5: Create a vector knowledge base
 
 A vector knowledge base in WSO2 Integrator: BI acts as an interface to a vector store and manages the ingestion and retrieval of documents.
 
@@ -85,7 +85,7 @@ A vector knowledge base in WSO2 Integrator: BI acts as an interface to a vector 
 !!! important "Embedding Dimensions"
     The **Default Embedding Provider (WSO2)** generates dense vectors with **1536 dimensions**. If you're using an external vector store (Pinecone, Milvus, Weaviate, etc.), ensure your vector store index is configured to support 1536-dimensional vectors.
 
-### Step 6: Ingest data into the knowledge base
+## Step 6: Ingest data into the knowledge base
 
 1. In the **Vector Knowledge Bases** section, click on `knowledgeBase`.
 2. Click on **ingest** to open the configuration panel.
@@ -96,7 +96,7 @@ A vector knowledge base in WSO2 Integrator: BI acts as an interface to a vector 
 
 This step chunks the document and sends them to the vector store, converting each chunk into an embedding and storing them for future retrieval.
 
-### Step 7: Add a confirmation message
+## Step 7: Add a confirmation message
 
 1. Hover over the flow line and click the **+** icon.
 2. Select **Log Info** under the **Logging** section.
@@ -107,7 +107,7 @@ This step chunks the document and sends them to the vector store, converting eac
 
 This step will print a confirmation once the ingestion is complete.
 
-### Step 8: Configure default WSO2 provider and run the integration
+## Step 8: Configure default WSO2 provider and run the integration
 
 1. As the workflow uses the `Default Embedding Provider (WSO2)`, you need to configure its settings:
     - Press `Ctrl/Cmd + Shift + P` to open the VS Code command palette.

--- a/en/docs/integration-guides/ai/rag/rag-query.md
+++ b/en/docs/integration-guides/ai/rag/rag-query.md
@@ -15,12 +15,12 @@ To get started, make sure you have completed the following steps:
     
     If you used an external vector store like Pinecone, Milvus, or Weaviate in the ingestion tutorial, you can create a separate project and configure the same external vector store connection.
 
-### Step 1: Open your existing integration project
+## Step 1: Open your existing integration project
 
 1. Open the `rag_ingestion` project that you created in the [RAG Ingestion Tutorial]({{base_path}}/integration-guides/ai/rag/rag-ingestion).
 2. When you run this integration, the ingestion automation will execute first, automatically loading your data into the in-memory vector store before the HTTP service becomes available.
 
-### Step 2: Create an HTTP service
+## Step 2: Create an HTTP service
 
 1. In the design view, click on the **Add Artifact** button.
 2. Select **HTTP Service** under the **Integration as API** category.
@@ -31,7 +31,7 @@ To get started, make sure you have completed the following steps:
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/rag/rag-query/create-an-http-service.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/rag/rag-query/create-an-http-service.gif" alt="Create an HTTP service" width="70%"></a>
 
-### Step 3: Update the resource method
+## Step 3: Update the resource method
 
 1. The service will have a default resource named `greeting` with the **GET** method. Click the edit button next to the `/greeting` resource.
 2. Change the HTTP method to **POST**.
@@ -42,7 +42,7 @@ To get started, make sure you have completed the following steps:
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/rag/rag-query/update-the-resource-method.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/rag/rag-query/update-the-resource-method.gif" alt="Update the resource method" width="70%"></a>
 
-### Step 4: Retrieve data from the knowledge base
+## Step 4: Retrieve data from the knowledge base
 
 Since you're working in the same project where you completed the ingestion tutorial, the vector knowledge base `knowledgeBase` that you created earlier is already available. You can use it to retrieve relevant chunks based on the user query.
 
@@ -60,7 +60,7 @@ Since you're working in the same project where you completed the ingestion tutor
 !!! note "Using External Vector Stores"
     If you have an external vector store (Pinecone, Milvus, Weaviate, etc.) with pre-ingested content, you can create a new vector knowledge base by clicking **+ Add Vector Knowledge Base** and following the instructions in [Step 5 of the RAG Ingestion Tutorial]({{base_path}}/integration-guides/ai/rag/rag-ingestion/#step-5-create-a-vector-knowledge-base). Make sure to configure the same vector store and embedding provider settings that were used during ingestion.
 
-### Step 5: Augment the user query with retrieved content
+## Step 5: Augment the user query with retrieved content
 
 WSO2 Integrator: BI includes a built-in function to augment the user query with retrieved context from the knowledge base. We'll use that in this step.
 
@@ -73,7 +73,7 @@ WSO2 Integrator: BI includes a built-in function to augment the user query with 
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/rag/rag-query/augment-user-query.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/rag/rag-query/augment-user-query.gif" alt="Augment the user query with retrieved content" width="70%"></a>
 
-### Step 6: Connect to an LLM provider
+## Step 6: Connect to an LLM provider
 
 After augmenting the query with retrieved context, we can now pass it to an LLM for a grounded response. WSO2 Integrator: BI provides an abstraction called `Model Provider` to connect with various LLM services.
 
@@ -86,7 +86,7 @@ After augmenting the query with retrieved context, we can now pass it to an LLM 
 
     <a href="{{base_path}}/assets/img/integration-guides/ai/rag/rag-query/create-a-model-provider.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/rag/rag-query/create-a-model-provider.gif" alt="Connect to an LLM provider" width="70%"></a>
 
-### Step 7: Generate the response
+## Step 7: Generate the response
 
 Now send the augmented query to the LLM to generate the grounded response.
 
@@ -102,7 +102,7 @@ Now send the augmented query to the LLM to generate the grounded response.
 !!! note "Understanding the Expression"
     The expression `check augmentedUserMsg.content.ensureType()` extracts the augmented query content and ensures it's in the correct string format that the LLM expects. The `check` keyword handles any potential type conversion errors.
 
-### Step 8: Return the response from the service resource
+## Step 8: Return the response from the service resource
 
 1. Hover over the flow line and click the **+** icon.
 2. Under the **Control** section, click on **Return**.
@@ -111,7 +111,7 @@ Now send the augmented query to the LLM to generate the grounded response.
     <a href="{{base_path}}/assets/img/integration-guides/ai/rag/rag-query/return-the-response-from-service-resource.gif"><img src="{{base_path}}/assets/img/integration-guides/ai/rag/rag-query/return-the-response-from-service-resource.gif" alt="Return the response from the service resource" width="70%"></a>
 
 
-### Step 9: Configure default WSO2 providers and run the integration
+## Step 9: Configure default WSO2 providers and run the integration
 
 1. As the workflow uses the `Default Model Provider (WSO2)` and `Default Embedding Provider (WSO2)`, you need to configure its settings:
     - Press `Ctrl/Cmd + Shift + P` to open the VS Code command palette.


### PR DESCRIPTION
## Purpose
Fix inconsistent heading levels in several guides, where step-by-step instructions (e.g., "Step 1: ...") were often nested as H3 headers under previous sections rather than being distinct H2 sections.
## Goals
 Standardize the heading hierarchy across AI documentation by promoting step headers from H3 to H2, ensuring a clear and consistent flow for users following the guides.
## Approach
 Updated the markdown files to change `### Step X` headers to `## Step X`.

 Affected files:
> - `develop-ai-agent.md`
> - `direct-llm-invocation-with-ballerina-model-providers.md`
> - `mcp-service.md`
> - `natural-functions.md`
> - `rag-ingestion.md`
> - `rag-query.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured AI integration guides with improved heading hierarchy for better navigation.
  * Expanded step-by-step tutorials with detailed instructions, examples, and clarifications.
  * Added explicit configuration steps and sample payloads for GraphQL resolvers, LLM integrations, MCP services, and RAG workflows.
  * Enhanced procedural guidance across AI agent setup, model provider configuration, and integration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->