### PR TITLE
Change title from 'Index' to 'Home'

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Index"
+title: "Home"
 description: "Home page for WSO2 Integrator: BI documentation, providing an overview of low-code integration features and capabilities."
 template: templates/home-page.html
 ---


### PR DESCRIPTION
## Purpose
The Google Search snippet for the WSO2 Integrator: BI Documentation homepage currently displays as "WSO2 Integrator: BI Documentation: Index". This happens because the `title` attribute in the `index.md` frontmatter is explicitly set to "Index", which is not SEO-friendly or ideal for user experience.
<img width="1380" height="667" alt="image" src="https://github.com/user-attachments/assets/375cf25d-1606-4ea0-9ce2-355dbd16d438" />


## Goals
Improve the SEO and search engine result page (SERP) appearance by changing the page title to something more descriptive and professional, preventing the word "Index" from appearing in search results.

## Approach
Changed the `title` property from `'Index'` to `'Home'` in the YAML frontmatter of `docs-bi/en/docs/index.md`. This allows the site generator to populate the HTML `<title>` tag correctly for search engine crawlers without changing the actual page content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the home page title from "Index" to "Home".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->