### PR TITLE
Fix typos and formatting in quick-start-guide.md

### DIFF
--- a/en/docs/get-started/quick-start-guide.md
+++ b/en/docs/get-started/quick-start-guide.md
@@ -5,13 +5,13 @@ description: "Step-by-step guide to quickly start building integrations with WSO
 
 # Quick Start Guide
 
-WSO2 Integrator: BI is a powerful low-code integration platform built on top of the <a href = "https://ballerina.io/">Ballerina programming language</a>. It’s designed to help developers quickly build, deploy, and manage integration solutions with minimal boilerplate and maximum productivity.
+WSO2 Integrator: BI is a powerful low-code integration platform built on top of the <a href="https://ballerina.io/">Ballerina programming language</a>. It's designed to help developers quickly build, deploy, and manage integration solutions with minimal boilerplate and maximum productivity.
 
 BI combines a visual design interface, AI-assisted development, and seamless low-code–to–pro-code transitions. With built-in connectors, flexible deployment options, and support for patterns like APIs, events, and automations, BI empowers teams to integrate faster and smarter.
 
-Whether you’re modernizing legacy systems or building cloud-native services, BI provides a productive and scalable path to integration, helping teams drive digital transformation with clarity, speed, and confidence.
+Whether you're modernizing legacy systems or building cloud-native services, BI provides a productive and scalable path to integration, helping teams drive digital transformation with clarity, speed, and confidence.
 
-<a href="{{base_path}}/assets/img/get-started/introduction/bi.png"><img src="{{base_path}}/assets/img/get-started/introduction/bi.png" alt="BI" width="90%" style="padding-top: 60px" ></a>
+<a href="{{base_path}}/assets/img/get-started/introduction/bi.png"><img src="{{base_path}}/assets/img/get-started/introduction/bi.png" alt="BI" width="90%" style="padding-top: 60px"></a>
 
 This quick start guide introduces five core integration types, each with a dedicated hands-on walkthrough.
 
@@ -19,9 +19,9 @@ This quick start guide introduces five core integration types, each with a dedic
 
 Create integrations that run on a timer—for example, to sync data, generate reports, or perform routine jobs. Follow [Develop your first automation](develop-automation.md) to get started.
 
-## AI agent
+## AI Agent
 
-Build agents that reason and act using GenAI models. Use them to respond to user input, access tools, or make decisions dynamically. Follow [Develop your first AI agent](develop-ai-agent.md) to get started. 
+Build agents that reason and act using GenAI models. Use them to respond to user input, access tools, or make decisions dynamically. Follow [Develop your first AI agent](develop-ai-agent.md) to get started.
 
 ## Integrations as APIs
 
@@ -32,7 +32,7 @@ Expose your integration as a real-time API that handles incoming requests and re
 Trigger your integration when messages arrive from sources like Kafka or RabbitMQ, enabling reactive workflows. Follow [Develop your first event integration](develop-event-integration.md) to get started.
 
 ## File Integration
- 
+
 Run your integration when files appear in a folder or FTP location—ideal for batch uploads or scheduled file processing. Follow [Develop your first file integration](develop-file-integration.md) to get started.
 
 Explore one or more quick start guides to experience how fast and flexible integration can be with BI.


### PR DESCRIPTION
Corrected typographical errors and improved formatting in the Quick Start Guide.

## Purpose
Fix typos and formatting issues in `quick-start-guide.md`.

## Goals
- Fix incorrect HTML attribute syntax (`href =` → `href=`)
- Fix curly apostrophe to straight apostrophe
- Fix heading capitalisation (`AI agent` → `AI Agent`)
- Remove trailing whitespace

## Approach
Direct text corrections with no functional changes.

## Documentation
N/A - This PR itself is a documentation fix.

## User stories
N/A

## Release note
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
- Followed secure coding standards: N/A (documentation only)
- Ran FindSecurityBugs plugin: N/A (documentation only)
- Confirmed no keys, passwords, or secrets committed: yes

## Samples
N/A

## Related PRs
N/A

## Migrations
N/A

## Test environment
N/A

## Learning
N/A